### PR TITLE
Only trigger workflows for relevant code changes

### DIFF
--- a/.github/workflows/package-project.yml
+++ b/.github/workflows/package-project.yml
@@ -6,7 +6,11 @@ on:
   push:
     branches: 
     - main
+    paths-ignore:
+    - '**.md'
   pull_request:
+    paths-ignore:
+    - '**.md'
 
 jobs:
   build-project:

--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -6,17 +6,13 @@ on:
   push:
     branches:
     - main
-    paths-ignore:
-    - 'tests/**'
-    - 'ui/**'
-    - '.github/**'
-    - '**.md'
+    paths:
+    - '!**.md'
+    - 'api/**'
   pull_request:
-    paths-ignore:
-    - 'tests/**'
-    - 'ui/**'
-    - '.github/**'
-    - '**.md'
+    paths:
+    - '!**.md'
+    - 'api/**'
 
 defaults:
   run:

--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -7,12 +7,12 @@ on:
     branches:
     - main
     paths:
-    - '!**.md'
     - 'api/**'
+    - '!**.md'
   pull_request:
     paths:
-    - '!**.md'
     - 'api/**'
+    - '!**.md'
 
 defaults:
   run:

--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -6,7 +6,17 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - 'tests/**'
+    - 'ui/**'
+    - '.github/**'
+    - '**.md'
   pull_request:
+    paths-ignore:
+    - 'tests/**'
+    - 'ui/**'
+    - '.github/**'
+    - '**.md'
 
 defaults:
   run:

--- a/.github/workflows/package-react.yml
+++ b/.github/workflows/package-react.yml
@@ -6,17 +6,13 @@ on:
   push:
     branches:
     - main
-    paths-ignore:
-    - 'tests/**'
-    - 'api/**'
-    - '.github/**'
-    - '**.md'
+    paths:
+    - '!**.md'
+    - 'ui/**'
   pull_request:
-    paths-ignore:
-    - 'tests/**'
-    - 'api/**'
-    - '.github/**'
-    - '**.md'
+    paths:
+    - '!**.md'
+    - 'ui/**'
 
 defaults:
   run:

--- a/.github/workflows/package-react.yml
+++ b/.github/workflows/package-react.yml
@@ -7,12 +7,12 @@ on:
     branches:
     - main
     paths:
-    - '!**.md'
     - 'ui/**'
+    - '!**.md'
   pull_request:
     paths:
-    - '!**.md'
     - 'ui/**'
+    - '!**.md'
 
 defaults:
   run:

--- a/.github/workflows/package-react.yml
+++ b/.github/workflows/package-react.yml
@@ -6,7 +6,17 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - 'tests/**'
+    - 'api/**'
+    - '.github/**'
+    - '**.md'
   pull_request:
+    paths-ignore:
+    - 'tests/**'
+    - 'api/**'
+    - '.github/**'
+    - '**.md'
 
 defaults:
   run:


### PR DESCRIPTION
This fixes #7

* We don't need to run Python code checks for React code changes, and vice versa
* We don't need to run code checks for markdown document changes

Documentation reference for syntax:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet