### PR TITLE
chore(init): login flow w material ui example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
+    "react-simple-oauth2-login": "^0.5.1",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },
@@ -26,12 +27,15 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint:fix": "eslint . --ext .ts,.js,.tsx,.jsx --fix",
-    "prepare": "husky install .husky"
+    "prepare": "husky install .husky",
+    "lint:js": "eslint . --ext .ts,.js,.tsx,.jsx",
+    "lint:prettier": "prettier \"**/*.js\" \"**/*.jsx\" \"**/*.json\" \"**/*.ts\" \"**/*.tsx\" \"**/*.scss\" --ignore-path .eslintignore --list-different",
+    "lint:fix": "npm run lint:js -- --fix",
+    "format:fix": "npm run lint:fix && npm run lint:prettier -- --write --ignore-path .eslintignore"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,scss}": [
-      "eslint . --ext .js,.jsx,.ts,.tsx --fix && prettier --write --ignore-path .eslintignore",
+      "npm run format:fix",
       "git add"
     ]
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import Header from 'src/components/Header/Header';
 import Dashboard from 'src/components/Dashboard/Dashboard';
 import ApiConfigService from 'src/services/ApiConfigService';
+import Authentication from 'src/components/Authentication';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -31,6 +32,7 @@ function App() {
 
   return (
     <div>
+      <Authentication />
       <CssBaseline />
       <Header />
       <Container maxWidth="xl">

--- a/src/components/Authentication/index.tsx
+++ b/src/components/Authentication/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import Avatar from '@material-ui/core/Avatar';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import TextField from '@material-ui/core/TextField';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import OAuth2Login from 'react-simple-oauth2-login';
+
+const onSuccess = (response: any) => {
+  console.log({ response });
+};
+const onFailure = (response: any) => {
+  console.log({ response });
+};
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    height: '100vh',
+  }, // TODO: turn into static image
+  image: {
+    backgroundImage:
+      'url(https://images.unsplash.com/photo-1595285203796-2da1c77274e4?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1400&q=80)',
+    backgroundRepeat: 'no-repeat',
+    backgroundColor: theme.palette.type === 'light' ? theme.palette.grey[50] : theme.palette.grey[900],
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+  },
+  paper: {
+    margin: theme.spacing(8, 4),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(1),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+}));
+
+export default function UnauthenticatedApp() {
+  const classes = useStyles();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const params = {
+    email,
+    password,
+  };
+  return (
+    <Grid container component="main" className={classes.root}>
+      <CssBaseline />
+      <Grid item xs={false} sm={4} md={7} className={classes.image} />
+      <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+        <div className={classes.paper}>
+          <Avatar className={classes.avatar}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component="h1" variant="h5">
+            Sign in
+          </Typography>
+          <form className={classes.form} noValidate>
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              autoFocus
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              name="password"
+              label="Password"
+              type="password"
+              id="password"
+              autoComplete="current-password"
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <OAuth2Login
+              className="login-button"
+              authorizationUrl={process.env.loginUrl}
+              clientId={process.env.clientId}
+              redirectUri={process.env.redirectUri}
+              scope={params}
+              responseType="token"
+              buttonText="Login"
+              onSuccess={onSuccess}
+              onFailure={onFailure}
+            />
+          </form>
+        </div>
+      </Grid>
+    </Grid>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "node",
@@ -24,6 +23,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "typeRoots": [
+      "./types/vendor.d.ts",
       "node_modules/@types"
     ],
     "noFallthroughCasesInSwitch": true,
@@ -36,6 +36,7 @@
   ],
   "compileOnSave": true,
   "include": [
-    "src"
+    "src/**/*",
+    "types/*"
   ]
 }

--- a/types/vendor.d.ts
+++ b/types/vendor.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-simple-oauth2-login';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10484,6 +10484,11 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-simple-oauth2-login@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-simple-oauth2-login/-/react-simple-oauth2-login-0.5.1.tgz#e2ee3c54f5cd8c746ba3c049d110c741e5498c0a"
+  integrity sha512-wvYYQ5FslVAILGEqKL2lorc2XcTKvN7HKTf3oqPNgkUNfRBe2b0SZJxkUKclgbH6Y65dOaVbRs/JuSQr8J47MQ==
+
 react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"


### PR DESCRIPTION
Changes:
----
* init authentication flow
* add oauth2 library to manage calls to back end
* fix various TS errors


<img width="1240" alt="Screen Shot 2021-09-03 at 11 26 17 AM" src="https://user-images.githubusercontent.com/8174488/132029987-ec1f5c35-ae0e-48a4-8472-2322b19ef6ec.png">

Tasks:
- figure out correct authentication with backend. "scope" params isn't returning a token
- add in logout
- track token and block <App/> until token/user is validated